### PR TITLE
stagefright: allow multiple custom OMXPlugins

### DIFF
--- a/media/libstagefright/omx/OMXMaster.cpp
+++ b/media/libstagefright/omx/OMXMaster.cpp
@@ -69,8 +69,13 @@ void OMXMaster::addVendorPlugin() {
 
 void OMXMaster::addUserPlugin() {
     char plugin[PROPERTY_VALUE_MAX];
+    char *each_plugin;
     if (property_get("media.sf.omx-plugin", plugin, NULL)) {
-        addPlugin(plugin);
+        each_plugin = strtok(plugin, ",");
+        while (each_plugin != NULL) {
+            addPlugin(each_plugin);
+            each_plugin = strtok(NULL, ",");
+        }
     }
 }
 


### PR DESCRIPTION
* Separated by comma(,)
* Example: media.sf.omx-plugin=libffmpeg_omx.so,libsomxcore.so

Change-Id: I15556a48df282b01f54ca864317eafff5468e739
Signed-off-by: Jesse Chan <jc@lineageos.org>