### PR TITLE
stagefright: Remove the HAL3 limitation from the video reference cloc…

### DIFF
--- a/media/libstagefright/CameraSource.cpp
+++ b/media/libstagefright/CameraSource.cpp
@@ -817,8 +817,7 @@ status_t CameraSource::start(MetaData *meta) {
         int64_t startTimeUs;
 
         auto key = kKeyTime;
-        if (property_get_bool("persist.camera.HAL3.enabled", true) &&
-             !property_get_bool("media.camera.ts.monotonic", true)) {
+        if (!property_get_bool("media.camera.ts.monotonic", true)) {
             key = kKeyTimeBoot;
         }
 

--- a/media/libstagefright/MediaCodecSource.cpp
+++ b/media/libstagefright/MediaCodecSource.cpp
@@ -772,8 +772,7 @@ status_t MediaCodecSource::onStart(MetaData *params) {
 
     if (mFlags & FLAG_USE_SURFACE_INPUT) {
         auto key = kKeyTime;
-        if (property_get_bool("persist.camera.HAL3.enabled", true) &&
-             !property_get_bool("media.camera.ts.monotonic", true)) {
+        if (!property_get_bool("media.camera.ts.monotonic", true)) {
             key = kKeyTimeBoot;
         }
 


### PR DESCRIPTION
…k selection

Usage of boot-time as the timestamp reference isn't necessarily limited to
HAL3. A single property check for media.camera.ts.monotonic is enough to
cover all cases.

RM-290
Change-Id: Ic56dbcc6ba32c25bccde6dd0bbf07d4c918af43e
(cherry picked from commit 2071f20583103d1ccf6102f84b2eedd6bb1214ba)