### PR TITLE
stagefright: Fix SurfaceMediaSource buffer search condition when buff…

### DIFF
--- a/media/libstagefright/SurfaceMediaSource.cpp
+++ b/media/libstagefright/SurfaceMediaSource.cpp
@@ -427,7 +427,11 @@ void SurfaceMediaSource::signalBufferReturned(MediaBuffer *buffer) {
     buffer_handle_t bufferHandle = getMediaBufferHandle(buffer);
 
     for (size_t i = 0; i < mCurrentBuffers.size(); i++) {
+#ifdef CAMCORDER_GRALLOC_SOURCE
         if (mCurrentBuffers[i]->handle == bufferHandle) {
+#else
+        if ((buffer_handle_t)mCurrentBuffers[i]->getNativeBuffer() == bufferHandle) {
+#endif
             mCurrentBuffers.removeAt(i);
             foundBuffer = true;
             break;
@@ -443,7 +447,11 @@ void SurfaceMediaSource::signalBufferReturned(MediaBuffer *buffer) {
             continue;
         }
 
+#ifdef CAMCORDER_GRALLOC_SOURCE
         if (bufferHandle == mSlots[id].mGraphicBuffer->handle) {
+#else
+        if (bufferHandle == (buffer_handle_t)mSlots[id].mGraphicBuffer->getNativeBuffer()) {
+#endif
             ALOGV("Slot %d returned, matches handle = %p", id,
                     mSlots[id].mGraphicBuffer->handle);
 


### PR DESCRIPTION
…er return

Refer to commit 3e328782f1e1061d08ea0c45b855cc418a2d9ea6, buffer
handle stored in MediaBuffer had changed, but the buffer return
code did not changed correspondly, so returned buffer can't be
found in list and lead to carsh.

This commit fix it and make wifidisplay working now.

Change-Id: Ic0d99f471f5f246087946367726d7e76a689fe1f