### PR TITLE
seccomp: Fix policy for ffmpeg

### DIFF
--- a/services/mediacodec/minijail/seccomp_policy/mediacodec-seccomp-arm-cm.policy
+++ b/services/mediacodec/minijail/seccomp_policy/mediacodec-seccomp-arm-cm.policy
@@ -7,3 +7,5 @@ recvfrom: 1
 _llseek: 1
 sysinfo: 1
 getcwd: 1
+# ffmpeg needs this
+getdents64: 1

--- a/services/mediaextractor/minijail/seccomp_policy/mediaextractor-seccomp-cm.policy
+++ b/services/mediaextractor/minijail/seccomp_policy/mediaextractor-seccomp-cm.policy
@@ -2,3 +2,5 @@
 # extension of services/mediaextractor/minijail/seccomp_policy/mediaextractor-seccomp-arm.policy
 readlinkat: 1
 pread64: 1
+# ffmpeg needs this
+nanosleep: 1


### PR DESCRIPTION
Without this, a bunch of cts tests fail.  For example:

android.media.cts.AdaptivePlaybackTest#testMpeg4_adaptiveDrc

fails with the log message:

E/media.codec( 8194): libminijail: blocked syscall: getdents64

and

android.security.cts.StagefrightTest#testStagefright_bug_25765591

fails because of a blocked call to nanosleep.

Change-Id: Iba99163c86e2941a8e821136188ddb3cf4d34a5c