### PR TITLE
CameraService: Fix cameraId type of onDeviceStatusChanged

### DIFF
--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -103,7 +103,7 @@ static void camera_device_status_change(
     sp<CameraService> cs = const_cast<CameraService*>(
             static_cast<const CameraService*>(callbacks));
 
-    cs->onDeviceStatusChanged(static_cast<camera_device_status_t>(camera_id),
+    cs->onDeviceStatusChanged(camera_id,
             static_cast<camera_device_status_t>(new_status));
 }
 
@@ -296,7 +296,7 @@ CameraService::~CameraService() {
     gCameraService = nullptr;
 }
 
-void CameraService::onDeviceStatusChanged(camera_device_status_t  cameraId,
+void CameraService::onDeviceStatusChanged(int cameraId,
         camera_device_status_t newStatus) {
     ALOGI("%s: Status changed for cameraId=%d, newStatus=%d", __FUNCTION__,
           cameraId, newStatus);

--- a/services/camera/libcameraservice/CameraService.h
+++ b/services/camera/libcameraservice/CameraService.h
@@ -99,7 +99,7 @@ public:
 
     /////////////////////////////////////////////////////////////////////
     // HAL Callbacks
-    virtual void        onDeviceStatusChanged(camera_device_status_t cameraId,
+    virtual void        onDeviceStatusChanged(int cameraId,
                                               camera_device_status_t newStatus);
     virtual void        onTorchStatusChanged(const String8& cameraId,
                                              int32_t newStatus);


### PR DESCRIPTION
The cameraId should be of type int, instead of camera_device_status_t.

Change-Id: I26d587bb74f7100028f09928984c2e8dad6eebef
Signed-off-by: Bin Chen <chen_bin@projectara.com>