### PR TITLE
Camera: check metadata type before releasing frame

### DIFF
--- a/services/camera/libcameraservice/device1/CameraHardwareInterface.cpp
+++ b/services/camera/libcameraservice/device1/CameraHardwareInterface.cpp
@@ -595,12 +595,16 @@ void CameraHardwareInterface::releaseRecordingFrame(const sp<IMemory>& mem)
     if (CC_LIKELY(mHidlDevice != nullptr)) {
         if (size == sizeof(VideoNativeHandleMetadata)) {
             VideoNativeHandleMetadata* md = (VideoNativeHandleMetadata*) mem->pointer();
-            // Caching the handle here because md->pHandle will be subject to HAL's edit
-            native_handle_t* nh = md->pHandle;
-            hidl_handle frame = nh;
-            mHidlDevice->releaseRecordingFrameHandle(heapId, bufferIndex, frame);
-            native_handle_close(nh);
-            native_handle_delete(nh);
+            if (md->eType == kMetadataBufferTypeNativeHandleSource) {
+                // Caching the handle here because md->pHandle will be subject to HAL's edit
+                native_handle_t* nh = md->pHandle;
+                hidl_handle frame = nh;
+                mHidlDevice->releaseRecordingFrameHandle(heapId, bufferIndex, frame);
+                native_handle_close(nh);
+                native_handle_delete(nh);
+            } else {
+                mHidlDevice->releaseRecordingFrame(heapId, bufferIndex);
+            }
         } else {
             mHidlDevice->releaseRecordingFrame(heapId, bufferIndex);
         }


### PR DESCRIPTION
Hidl method releaseRecordingFrameHandle fails for metadata
type other than kMetadataBufferTypeNativeHandleSource which
prevents older devices to record video.

Change-Id: I0e84883bdb636e965526ca1282216baef43e87e8