### PR TITLE
audiopolicy: update APM to use custom audio policy configuration

### DIFF
--- a/services/audiopolicy/managerdefault/AudioPolicyManager.cpp
+++ b/services/audiopolicy/managerdefault/AudioPolicyManager.cpp
@@ -3555,7 +3555,7 @@ uint32_t AudioPolicyManager::nextAudioPortGeneration()
 #ifdef USE_XML_AUDIO_POLICY_CONF
 // Treblized audio policy xml config will be located in /odm/etc or /vendor/etc.
 static const char *kConfigLocationList[] =
-        {"/odm/etc", "/vendor/etc", "/system/etc"};
+        {"/odm/etc", "/vendor/etc/audio", "/vendor/etc", "/system/etc"};
 static const int kConfigLocationListSize =
         (sizeof(kConfigLocationList) / sizeof(kConfigLocationList[0]));
 


### PR DESCRIPTION
Update AudioPolicyManager to use custom audio_policy_configuration.xml
if available.
This is to avoid keeping qti value added customization in default policy
configuration, since with treble design vts expects default vendor
policy configuration to be supported even with aosp system image but that
aosp system image would not have qti customization support and hence might
result in failures.

Change-Id: I3161ff4fa41d37d0b761202f0b3a490d9c7e418e